### PR TITLE
fix: split beans.ts to avoid Luau 200 register limit

### DIFF
--- a/.ghlp-metadata.json
+++ b/.ghlp-metadata.json
@@ -1,0 +1,11 @@
+{
+  "originalUrl": "ghlp://github.com/white-dragon-bevy/ts-to-luban/issues/1",
+  "originType": "issue",
+  "mapped": false,
+  "type": "issue",
+  "org": "white-dragon-bevy",
+  "repo": "ts-to-luban",
+  "identifier": "1",
+  "branch": "issue-1",
+  "createdAt": "2026-02-04T06:54:06.113Z"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "luban-gen"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luban-gen"
-version = "0.4.7"
+version = "0.5.0"
 edition = "2021"
 description = "High-performance TypeScript to Luban XML Schema generator"
 

--- a/examples/configs/defines/constructor-type.xml
+++ b/examples/configs/defines/constructor-type.xml
@@ -1,14 +1,14 @@
 <module name="constructor" comment="自动生成的 ts class Bean 定义">
 
     <!-- Character configuration with constructor type field -->
-    <bean name="CharacterConfig" parent="TsClass" comment="Character configuration with constructor type field">
+    <bean name="CharacterConfig" comment="Character configuration with constructor type field">
         <var name="id" type="double"/>
         <var name="name" type="string"/>
         <var name="triggerType" type="string#constructor=BaseTrigger" comment="In Excel, store class name like &quot;DamageTrigger&quot; or &quot;HealTrigger&quot;"/>
     </bean>
 
     <!-- Base trigger class -->
-    <bean name="BaseTrigger" parent="TsClass" comment="Base trigger class">
+    <bean name="BaseTrigger" comment="Base trigger class">
         <var name="id" type="double"/>
         <var name="priority" type="double"/>
     </bean>

--- a/examples/configs/defines/dollar-type.xml
+++ b/examples/configs/defines/dollar-type.xml
@@ -1,7 +1,7 @@
 <module name="dollar_type" comment="自动生成的 ts class Bean 定义">
 
     <!-- $type&lt;T&gt; 类型包装器示例 $type&lt;T&gt; 会在生成时提取内部类型 T，忽略 $type 包装器 -->
-    <bean name="BaseEntity" parent="TsClass" comment="$type&lt;T&gt; 类型包装器示例 $type&lt;T&gt; 会在生成时提取内部类型 T，忽略 $type 包装器">
+    <bean name="BaseEntity" comment="$type&lt;T&gt; 类型包装器示例 $type&lt;T&gt; 会在生成时提取内部类型 T，忽略 $type 包装器">
         <var name="id" type="double"/>
         <var name="name" type="string"/>
     </bean>
@@ -15,7 +15,7 @@
     </bean>
 
     <!-- 使用 $type&lt;T&gt; 包装器的配置类 -->
-    <bean name="EntityConfig" parent="TsClass" comment="使用 $type&lt;T&gt; 包装器的配置类">
+    <bean name="EntityConfig" comment="使用 $type&lt;T&gt; 包装器的配置类">
         <var name="entityType" type="BaseEntity" comment="实体类型 - 使用 $type 包装"/>
         <var name="entities" type="list,BaseEntity" comment="实体列表"/>
         <var name="entityMap" type="map,string,BaseEntity" comment="实体映射"/>
@@ -23,7 +23,7 @@
     </bean>
 
     <!-- 嵌套使用示例 -->
-    <bean name="ComplexConfig" parent="TsClass" comment="嵌套使用示例">
+    <bean name="ComplexConfig" comment="嵌套使用示例">
         <var name="heroType" type="Hero" comment="英雄类型"/>
         <var name="enemyType" type="Enemy" comment="敌人类型"/>
         <var name="mixedList" type="list,BaseEntity" comment="混合列表"/>

--- a/examples/configs/defines/examples.xml
+++ b/examples/configs/defines/examples.xml
@@ -1,7 +1,7 @@
 <module name="examples" comment="自动生成的 ts class Bean 定义">
 
     <!-- 道具配置 -->
-    <bean name="Item" alias="道具" parent="TsClass" comment="道具配置">
+    <bean name="Item" alias="道具" comment="道具配置">
         <var name="id" type="double" alias="物品ID"/>
         <var name="name" type="string!" alias="名称" comment="物品名称"/>
         <var name="category" type="string#set=weapon,armor,consumable,material"/>
@@ -9,21 +9,21 @@
     </bean>
 
     <!-- 技能配置 -->
-    <bean name="Skill" alias="技能" parent="TsClass" comment="技能配置">
+    <bean name="Skill" alias="技能" comment="技能配置">
         <var name="id" type="double"/>
         <var name="skillName" type="string!"/>
         <var name="cooldown" type="double#range=[0,100]"/>
     </bean>
 
     <!-- 掉落物品 -->
-    <bean name="DropItem" parent="TsClass" comment="掉落物品">
+    <bean name="DropItem" comment="掉落物品">
         <var name="itemId" type="double" comment="道具ID"/>
         <var name="count" type="double#range=[1,100]"/>
         <var name="probability" type="double#range=[0,100]"/>
     </bean>
 
     <!-- 怪物配置 -->
-    <bean name="Monster" alias="怪物" parent="TsClass" comment="怪物配置">
+    <bean name="Monster" alias="怪物" comment="怪物配置">
         <var name="id" type="double"/>
         <var name="name" type="string!"/>
         <var name="level" type="double#range=[1,100]"/>
@@ -33,7 +33,7 @@
     </bean>
 
     <!-- 玩家信息 -->
-    <bean name="Player" parent="TsClass" comment="玩家信息">
+    <bean name="Player" comment="玩家信息">
         <var name="id" type="double"/>
         <var name="name" type="string!"/>
         <var name="avatar" type="string!"/>
@@ -41,14 +41,14 @@
     </bean>
 
     <!-- 难度配置 -->
-    <bean name="Difficulty" parent="TsClass" comment="难度配置">
+    <bean name="Difficulty" comment="难度配置">
         <var name="id" type="double"/>
         <var name="difficultyLevel" type="double#range=[1,3]"/>
         <var name="difficultyName" type="string"/>
     </bean>
 
     <!-- 队伍配置 -->
-    <bean name="Team" parent="TsClass" comment="队伍配置">
+    <bean name="Team" comment="队伍配置">
         <var name="id" type="double"/>
         <var name="members" type="(list#size=3),double" comment="固定3人"/>
         <var name="substitutes" type="(list#size=[0,2]),double" comment="0-2人替补"/>

--- a/examples/configs/defines/field-visibility.xml
+++ b/examples/configs/defines/field-visibility.xml
@@ -1,7 +1,7 @@
 <module name="field_visibility" comment="自动生成的 ts class Bean 定义">
 
     <!-- Test class with private fields Private fields should be excluded from bean and creator generation -->
-    <bean name="TestPrivateFields" parent="TsClass" comment="Test class with private fields Private fields should be excluded from bean and creator generation">
+    <bean name="TestPrivateFields" comment="Test class with private fields Private fields should be excluded from bean and creator generation">
         <var name="id" type="double"/>
         <var name="name" type="string!"/>
     </bean>
@@ -13,7 +13,7 @@
     </bean>
 
     <!-- Test class with readonly fields Readonly fields should use Writable&lt;T&gt; cast in creator -->
-    <bean name="TestReadonlyFields" parent="TsClass" comment="Test class with readonly fields Readonly fields should use Writable&lt;T&gt; cast in creator">
+    <bean name="TestReadonlyFields" comment="Test class with readonly fields Readonly fields should use Writable&lt;T&gt; cast in creator">
         <var name="id" type="double"/>
         <var name="createdAt" type="double"/>
         <var name="updatedAt" type="double"/>

--- a/examples/configs/defines/inheritance.xml
+++ b/examples/configs/defines/inheritance.xml
@@ -1,7 +1,7 @@
 <module name="inheritance" comment="自动生成的 ts class Bean 定义">
 
     <!-- 基础单位 -->
-    <bean name="BaseUnit" parent="TsClass" comment="基础单位">
+    <bean name="BaseUnit" comment="基础单位">
         <var name="id" type="double"/>
         <var name="name" type="string!"/>
     </bean>
@@ -24,7 +24,7 @@
     </bean>
 
     <!-- 独立单位 - 无继承 -->
-    <bean name="StandaloneUnit" parent="TsClass" comment="独立单位 - 无继承">
+    <bean name="StandaloneUnit" comment="独立单位 - 无继承">
         <var name="data" type="string"/>
     </bean>
 

--- a/examples/configs/defines/items.xml
+++ b/examples/configs/defines/items.xml
@@ -1,7 +1,7 @@
 <module name="items" comment="自动生成的 ts class Bean 定义">
 
     <!-- 武器配置 -->
-    <bean name="Weapon" alias="武器" parent="TsClass" comment="武器配置">
+    <bean name="Weapon" alias="武器" comment="武器配置">
         <var name="id" type="double"/>
         <var name="name" type="string!"/>
         <var name="damage" type="double#range=[1,100]"/>
@@ -9,14 +9,14 @@
     </bean>
 
     <!-- 防具配置 -->
-    <bean name="Armor" alias="防具" parent="TsClass" comment="防具配置">
+    <bean name="Armor" alias="防具" comment="防具配置">
         <var name="id" type="double"/>
         <var name="name" type="string!"/>
         <var name="defense" type="double#range=[1,500]"/>
     </bean>
 
     <!-- 装备套装 -->
-    <bean name="EquipmentSet" parent="TsClass" comment="装备套装">
+    <bean name="EquipmentSet" comment="装备套装">
         <var name="weaponId" type="double"/>
         <var name="armorId" type="double"/>
     </bean>

--- a/examples/configs/defines/table-modes.xml
+++ b/examples/configs/defines/table-modes.xml
@@ -1,14 +1,14 @@
 <module name="modes" comment="自动生成的 ts class Bean 定义">
 
     <!-- 排行榜条目 - list mode (纯数组，无索引) -->
-    <bean name="LeaderboardEntry" parent="TsClass" comment="排行榜条目 - list mode (纯数组，无索引)">
+    <bean name="LeaderboardEntry" comment="排行榜条目 - list mode (纯数组，无索引)">
         <var name="rank" type="double"/>
         <var name="playerId" type="double"/>
         <var name="score" type="double"/>
     </bean>
 
     <!-- 游戏全局配置 - one mode (单条记录) -->
-    <bean name="GameConfig" parent="TsClass" comment="游戏全局配置 - one mode (单条记录)">
+    <bean name="GameConfig" comment="游戏全局配置 - one mode (单条记录)">
         <var name="id" type="double"/>
         <var name="maxPlayers" type="double"/>
         <var name="gameVersion" type="string"/>
@@ -16,7 +16,7 @@
     </bean>
 
     <!-- 服务器设置 - singleton mode (单例) -->
-    <bean name="ServerSettings" parent="TsClass" comment="服务器设置 - singleton mode (单例)">
+    <bean name="ServerSettings" comment="服务器设置 - singleton mode (单例)">
         <var name="id" type="double"/>
         <var name="serverName" type="string"/>
         <var name="tickRate" type="double"/>

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@white-dragon-bevy/ts-to-luban",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "main": "out/init.lua",
   "types": "out/index.d.ts",
   "type": "module",

--- a/examples/src/types/configs/beans.ts
+++ b/examples/src/types/configs/beans.ts
@@ -1,11 +1,11 @@
-import { Weapon, Armor, EquipmentSet } from "../../__examples__/items";
-import { BaseUnit, CharacterUnit, PlayerUnit, NPCUnit, StandaloneUnit } from "../../__examples__/inheritance";
+import { Difficulty, DropItem, Item, Monster, Player, Skill, Team } from "../../__examples__/all-validators";
+import { BaseTrigger, CharacterConfig, DamageTrigger, HealTrigger } from "../../__examples__/constructor-type";
 import { CircleShape, RectangleShape } from "../../__examples__/discriminated-union";
-import { LeaderboardEntry, GameConfig, ServerSettings } from "../../__examples__/table-modes";
-import { Item, Skill, DropItem, Monster, Player, Difficulty, Team } from "../../__examples__/all-validators";
-import { BaseTrigger, DamageTrigger, HealTrigger, CharacterConfig } from "../../__examples__/constructor-type";
+import { BaseEntity, ComplexConfig, Enemy, EntityConfig, Hero } from "../../__examples__/dollar-type";
 import { TestPrivateFields, TestReadonlyFields } from "../../__examples__/field-visibility";
-import { BaseEntity, Hero, Enemy, EntityConfig, ComplexConfig } from "../../__examples__/dollar-type";
+import { BaseUnit, CharacterUnit, NPCUnit, PlayerUnit, StandaloneUnit } from "../../__examples__/inheritance";
+import { Armor, EquipmentSet, Weapon } from "../../__examples__/items";
+import { GameConfig, LeaderboardEntry, ServerSettings } from "../../__examples__/table-modes";
 
 export const Beans = {
     "constructor.BaseTrigger": BaseTrigger,

--- a/examples/src/types/configs/tables.d.ts
+++ b/examples/src/types/configs/tables.d.ts
@@ -1,5 +1,5 @@
-import { CharacterConfig } from "../../__examples__/constructor-type";
 import { LeaderboardEntry, GameConfig, ServerSettings } from "../../__examples__/table-modes";
+import { CharacterConfig } from "../../__examples__/constructor-type";
 import { Weapon, Armor } from "../../__examples__/items";
 
 export interface AllTables {

--- a/src/ts_generator/beans_gen.rs
+++ b/src/ts_generator/beans_gen.rs
@@ -3,7 +3,19 @@ use crate::ts_generator::import_resolver::ImportResolver;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+/// Maximum number of imports per file to stay under Luau's 200 register limit
+const MAX_IMPORTS_PER_FILE: usize = 100;
+
+/// Represents a generated beans file
+pub struct BeansFile {
+    /// File name (e.g., "beans.ts", "beans_1.ts")
+    pub filename: String,
+    /// File content
+    pub content: String,
+}
+
 /// Beans generator - generates a dictionary of all classes with module.name keys
+/// Splits into multiple files to avoid Luau's 200 register limit
 pub struct BeansGenerator<'a> {
     import_resolver: &'a ImportResolver,
 }
@@ -13,15 +25,14 @@ impl<'a> BeansGenerator<'a> {
         Self { import_resolver }
     }
 
-    /// Generate beans.ts with all classes and interfaces
+    /// Generate beans files - returns multiple files if needed to avoid register limit
+    /// Returns: Vec of (filename, content) pairs
     pub fn generate(
         &self,
         all_classes: &[&ClassInfo],
         output_path: &Path,
         default_module: &str,
-    ) -> String {
-        let mut lines = Vec::new();
-
+    ) -> Vec<BeansFile> {
         // Only include classes (not interfaces), deduplicate by name
         let mut seen = std::collections::HashSet::new();
         let classes: Vec<_> = all_classes
@@ -30,23 +41,53 @@ impl<'a> BeansGenerator<'a> {
             .copied()
             .collect();
 
-        // Collect imports grouped by source file
-        let mut imports = HashMap::new();
+        // Collect imports grouped by source file, and count total imports
+        let mut imports_by_file: HashMap<String, Vec<&str>> = HashMap::new();
         for class in &classes {
             let source_path = PathBuf::from(&class.source_file);
             let import_path = self.import_resolver.resolve(output_path, &source_path);
 
-            imports
+            imports_by_file
                 .entry(import_path)
                 .or_insert_with(Vec::new)
                 .push(class.name.as_str());
         }
 
-        // Generate import statements
-        for (import_path, class_names) in imports {
+        // Count total number of imported identifiers
+        let total_imports: usize = imports_by_file.values().map(|v| v.len()).sum();
+
+        // If under limit, generate single file (backward compatible)
+        if total_imports <= MAX_IMPORTS_PER_FILE {
+            let content = self.generate_single_file(&classes, &imports_by_file, default_module);
+            return vec![BeansFile {
+                filename: "beans.ts".to_string(),
+                content,
+            }];
+        }
+
+        // Need to split into multiple files
+        self.generate_split_files(&classes, output_path, default_module)
+    }
+
+    /// Generate a single beans.ts file (original behavior)
+    fn generate_single_file(
+        &self,
+        classes: &[&ClassInfo],
+        imports_by_file: &HashMap<String, Vec<&str>>,
+        default_module: &str,
+    ) -> String {
+        let mut lines = Vec::new();
+
+        // Generate import statements (sorted for deterministic output)
+        let mut sorted_imports: Vec<_> = imports_by_file.iter().collect();
+        sorted_imports.sort_by(|a, b| a.0.cmp(b.0));
+
+        for (import_path, class_names) in sorted_imports {
+            let mut sorted_names = class_names.clone();
+            sorted_names.sort();
             lines.push(format!(
                 "import {{ {} }} from \"{}\";",
-                class_names.join(", "),
+                sorted_names.join(", "),
                 import_path
             ));
         }
@@ -80,6 +121,178 @@ impl<'a> BeansGenerator<'a> {
         lines.join("\n")
     }
 
+    /// Generate split beans files: beans_1.ts, beans_2.ts, ... and beans.ts (merger)
+    fn generate_split_files(
+        &self,
+        classes: &[&ClassInfo],
+        output_path: &Path,
+        default_module: &str,
+    ) -> Vec<BeansFile> {
+        let mut result = Vec::new();
+
+        // Sort classes by bean key for deterministic splitting
+        let mut sorted_classes: Vec<_> = classes.to_vec();
+        sorted_classes.sort_by(|a, b| {
+            let key_a = self.get_bean_key(a, default_module);
+            let key_b = self.get_bean_key(b, default_module);
+            key_a.cmp(&key_b)
+        });
+
+        // Split classes into chunks based on import count
+        let chunks = self.split_by_import_count(&sorted_classes, output_path);
+
+        // Generate each chunk file (beans_1.ts, beans_2.ts, ...)
+        for (chunk_index, chunk_classes) in chunks.iter().enumerate() {
+            let chunk_num = chunk_index + 1;
+            let filename = format!("beans_{}.ts", chunk_num);
+            let export_name = format!("Beans_{}", chunk_num);
+
+            let content = self.generate_chunk_file(
+                chunk_classes,
+                output_path,
+                default_module,
+                &export_name,
+            );
+
+            result.push(BeansFile { filename, content });
+        }
+
+        // Generate main beans.ts that merges all chunks
+        let main_content = self.generate_main_file(chunks.len());
+        result.push(BeansFile {
+            filename: "beans.ts".to_string(),
+            content: main_content,
+        });
+
+        result
+    }
+
+    /// Split classes into chunks, ensuring each chunk stays under the import limit
+    fn split_by_import_count<'b>(
+        &self,
+        classes: &[&'b ClassInfo],
+        output_path: &Path,
+    ) -> Vec<Vec<&'b ClassInfo>> {
+        let mut chunks: Vec<Vec<&'b ClassInfo>> = Vec::new();
+        let mut current_chunk: Vec<&'b ClassInfo> = Vec::new();
+        let mut current_imports: HashMap<String, usize> = HashMap::new();
+        let mut current_import_count: usize = 0;
+
+        for class in classes {
+            let source_path = PathBuf::from(&class.source_file);
+            let import_path = self.import_resolver.resolve(output_path, &source_path);
+
+            if !current_chunk.is_empty() && current_import_count + 1 > MAX_IMPORTS_PER_FILE {
+                // Start a new chunk
+                chunks.push(current_chunk);
+                current_chunk = Vec::new();
+                current_imports.clear();
+                current_import_count = 0;
+            }
+
+            // Add class to current chunk
+            current_chunk.push(class);
+            *current_imports.entry(import_path).or_insert(0) += 1;
+            current_import_count += 1;
+        }
+
+        // Don't forget the last chunk
+        if !current_chunk.is_empty() {
+            chunks.push(current_chunk);
+        }
+
+        chunks
+    }
+
+    /// Generate a chunk file (beans_N.ts)
+    fn generate_chunk_file(
+        &self,
+        classes: &[&ClassInfo],
+        output_path: &Path,
+        default_module: &str,
+        export_name: &str,
+    ) -> String {
+        let mut lines = Vec::new();
+
+        // Collect imports grouped by source file
+        let mut imports_by_file: HashMap<String, Vec<&str>> = HashMap::new();
+        for class in classes {
+            let source_path = PathBuf::from(&class.source_file);
+            let import_path = self.import_resolver.resolve(output_path, &source_path);
+
+            imports_by_file
+                .entry(import_path)
+                .or_insert_with(Vec::new)
+                .push(class.name.as_str());
+        }
+
+        // Generate import statements (sorted for deterministic output)
+        let mut sorted_imports: Vec<_> = imports_by_file.iter().collect();
+        sorted_imports.sort_by(|a, b| a.0.cmp(b.0));
+
+        for (import_path, class_names) in sorted_imports {
+            let mut sorted_names = class_names.clone();
+            sorted_names.sort();
+            lines.push(format!(
+                "import {{ {} }} from \"{}\";",
+                sorted_names.join(", "),
+                import_path
+            ));
+        }
+
+        if !lines.is_empty() {
+            lines.push(String::new());
+        }
+
+        // Generate export const
+        lines.push(format!("export const {} = {{", export_name));
+
+        // Collect bean entries and sort them
+        let mut bean_entries: Vec<_> = classes
+            .iter()
+            .map(|class| {
+                let key = self.get_bean_key(class, default_module);
+                let value = &class.name;
+                (key, value)
+            })
+            .collect();
+
+        bean_entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+        // Generate bean entries
+        for (key, value) in bean_entries {
+            lines.push(format!("    \"{}\": {},", key, value));
+        }
+
+        lines.push("} as const;".to_string());
+
+        lines.join("\n")
+    }
+
+    /// Generate main beans.ts that merges all chunk files
+    fn generate_main_file(&self, chunk_count: usize) -> String {
+        let mut lines = Vec::new();
+
+        // Import all chunks
+        for i in 1..=chunk_count {
+            lines.push(format!(
+                "import {{ Beans_{} }} from \"./beans_{}\";",
+                i, i
+            ));
+        }
+
+        lines.push(String::new());
+
+        // Merge all chunks into Beans
+        lines.push("export const Beans = {".to_string());
+        for i in 1..=chunk_count {
+            lines.push(format!("    ...Beans_{},", i));
+        }
+        lines.push("} as const;".to_string());
+
+        lines.join("\n")
+    }
+
     /// Get module name for a class
     fn get_module_name(&self, class: &ClassInfo, default_module: &str) -> String {
         class
@@ -106,6 +319,10 @@ mod tests {
     use crate::parser::ClassInfo;
 
     fn make_class(name: &str, is_interface: bool) -> ClassInfo {
+        make_class_with_source(name, is_interface, "test.ts")
+    }
+
+    fn make_class_with_source(name: &str, is_interface: bool, source_file: &str) -> ClassInfo {
         ClassInfo {
             name: name.to_string(),
             comment: None,
@@ -113,7 +330,7 @@ mod tests {
             fields: vec![],
             implements: vec![],
             extends: None,
-            source_file: "test.ts".to_string(),
+            source_file: source_file.to_string(),
             file_hash: "".to_string(),
             is_interface,
             output_path: None,
@@ -136,7 +353,13 @@ mod tests {
         let class2 = make_class("AnotherClass", false);
 
         let all_classes: Vec<&ClassInfo> = vec![&class1, &interface1, &class2];
-        let output = generator.generate(&all_classes, Path::new("out/beans.ts"), "test");
+        let files = generator.generate(&all_classes, Path::new("out/beans.ts"), "test");
+
+        // Should generate single file for small number of classes
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].filename, "beans.ts");
+
+        let output = &files[0].content;
 
         // Should include classes
         assert!(output.contains("MyClass"), "Should include MyClass");
@@ -158,7 +381,10 @@ mod tests {
         let interface2 = make_class("Interface2", true);
 
         let all_classes: Vec<&ClassInfo> = vec![&interface1, &interface2];
-        let output = generator.generate(&all_classes, Path::new("out/beans.ts"), "test");
+        let files = generator.generate(&all_classes, Path::new("out/beans.ts"), "test");
+
+        assert_eq!(files.len(), 1);
+        let output = &files[0].content;
 
         // Should have empty Beans object
         assert!(output.contains("export const Beans = {"));
@@ -167,5 +393,57 @@ mod tests {
         assert!(!output.contains("import"));
         assert!(!output.contains("Interface1"));
         assert!(!output.contains("Interface2"));
+    }
+
+    #[test]
+    fn test_beans_generator_splits_when_over_limit() {
+        let import_resolver = ImportResolver::default();
+        let generator = BeansGenerator::new(&import_resolver);
+
+        // Create 200 classes (over the 150 limit)
+        let classes: Vec<ClassInfo> = (0..200)
+            .map(|i| make_class_with_source(&format!("Class{}", i), false, &format!("file{}.ts", i)))
+            .collect();
+
+        let all_classes: Vec<&ClassInfo> = classes.iter().collect();
+        let files = generator.generate(&all_classes, Path::new("out/beans.ts"), "test");
+
+        // Should generate multiple files
+        assert!(files.len() > 1, "Should generate multiple files for 200 classes");
+
+        // Should have beans_1.ts, beans_2.ts, ... and beans.ts
+        let filenames: Vec<_> = files.iter().map(|f| f.filename.as_str()).collect();
+        assert!(filenames.contains(&"beans.ts"), "Should have main beans.ts");
+        assert!(filenames.contains(&"beans_1.ts"), "Should have beans_1.ts");
+
+        // Main beans.ts should import and spread chunks
+        let main_file = files.iter().find(|f| f.filename == "beans.ts").unwrap();
+        assert!(main_file.content.contains("import { Beans_1 }"), "Should import Beans_1");
+        assert!(main_file.content.contains("...Beans_1"), "Should spread Beans_1");
+
+        // Chunk files should export Beans_N
+        let chunk1 = files.iter().find(|f| f.filename == "beans_1.ts").unwrap();
+        assert!(chunk1.content.contains("export const Beans_1 = {"), "Should export Beans_1");
+    }
+
+    #[test]
+    fn test_beans_generator_no_split_under_limit() {
+        let import_resolver = ImportResolver::default();
+        let generator = BeansGenerator::new(&import_resolver);
+
+        // Create 50 classes (under the 150 limit)
+        let classes: Vec<ClassInfo> = (0..50)
+            .map(|i| make_class_with_source(&format!("Class{}", i), false, &format!("file{}.ts", i)))
+            .collect();
+
+        let all_classes: Vec<&ClassInfo> = classes.iter().collect();
+        let files = generator.generate(&all_classes, Path::new("out/beans.ts"), "test");
+
+        // Should generate single file
+        assert_eq!(files.len(), 1, "Should generate single file for 50 classes");
+        assert_eq!(files[0].filename, "beans.ts");
+
+        // Should NOT have chunk imports
+        assert!(!files[0].content.contains("Beans_1"), "Should not have chunk references");
     }
 }

--- a/src/ts_generator/mod.rs
+++ b/src/ts_generator/mod.rs
@@ -74,16 +74,21 @@ impl<'a> TsCodeGenerator<'a> {
         let content = tables_gen.generate(&table_classes, &tables_path);
         std::fs::write(&tables_path, content)?;
 
-        // Generate beans.ts with all classes
+        // Generate beans.ts (and beans_N.ts if needed) with all classes
         let all_class_refs: Vec<_> = self.classes.iter().collect();
         let beans_gen = BeansGenerator::new(&self.import_resolver);
         let beans_path = self.output_path.join("beans.ts");
-        let beans_content = beans_gen.generate(
+        let beans_files = beans_gen.generate(
             &all_class_refs,
             &beans_path,
             self.get_default_module_name(),
         );
-        std::fs::write(&beans_path, beans_content)?;
+        
+        // Write all beans files
+        for beans_file in beans_files {
+            let file_path = self.output_path.join(&beans_file.filename);
+            std::fs::write(&file_path, &beans_file.content)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Closes #1

## Problem
When beans.ts has 180+ imports, Luau compiler fails with:
\\\
Error: Out of local registers when trying to allocate Beans: exceeded limit 200
\\\

## Root Cause
Each \import { X }\ identifier occupies a Luau register. Not the object literal properties.

## Solution
Split beans generation into multiple files when imports exceed 100:
- \eans_1.ts\, \eans_2.ts\, ... for chunks (max 100 imports each)
- \eans.ts\ merges all chunks with spread operator

## Backward Compatible
Single file generated when under 100 imports limit.